### PR TITLE
Meta update project

### DIFF
--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -77,7 +77,7 @@ WSGI_APPLICATION = 'fotogalleri.wsgi.application'
 if not DEBUG:
     logging = {
         'version': 1,
-        'disable_existing_loggers': false,
+        'disable_existing_loggers': False,
         'handlers': {
             'file': {
                 'level': 'info',
@@ -89,7 +89,7 @@ if not DEBUG:
             'django': {
                 'handlers': ['file'],
                 'level': 'info',
-                'propagate': true,
+                'propagate': True,
             },
         },
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pep8]
+max-line-length = 119
+
+[flake8]
+max-line-length = 119


### PR DESCRIPTION
Fix typos found in `settings.py` and add a `setup.cfg` for configuring our PEP8 usage.

New in our linting:
- Line length to <120 chars for easier read of long Django commands