### PR TITLE
Fix logging in settings.py

### DIFF
--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -75,20 +75,20 @@ WSGI_APPLICATION = 'fotogalleri.wsgi.application'
 
 # Logging
 if not DEBUG:
-    logging = {
+    LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
         'handlers': {
             'file': {
-                'level': 'info',
-                'class': 'logging.filehandler',
+                'level': 'INFO',
+                'class': 'logging.FileHandler',
                 'filename': '/var/log/fotogalleri/info.log',
             },
         },
         'loggers': {
             'django': {
                 'handlers': ['file'],
-                'level': 'info',
+                'level': 'INFO',
                 'propagate': True,
             },
         },

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -91,6 +91,10 @@ if not DEBUG:
                 'level': 'INFO',
                 'propagate': True,
             },
+            'django_auth_ldap': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
         },
     }
 


### PR DESCRIPTION
This PR fixes logging configuration in `fotogalleri/fotogalleri/settings.py`.
For some reason configuration had become lower-case.