### PR TITLE
Thumbnail Queue

### DIFF
--- a/fotogalleri/.env.example
+++ b/fotogalleri/.env.example
@@ -45,3 +45,6 @@ DATABASE=sqlite:////path/to/tf-members/postgres
 #EMAIL_HOST_USER="email_user@gmail.com"
 #EMAIL_HOST_PASSWORD="verySecure"
 #EMAIL_USE_TLS=True
+
+# Thread amount for thumbnail queue
+THUMB_QUEUE_THREAD_COUNT=4

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -45,6 +45,10 @@ class ThumbQueue():
             pass
 
     @staticmethod
+    def is_empty():
+        return ThumbQueue._THUMB_QUEUE.empty()
+
+    @staticmethod
     def stop():
         ThumbQueue._THUMB_QUEUE.join()
 

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -1,6 +1,10 @@
 from django.conf.settings import THUMB_QUEUE_THREAD_COUNT
 from queue import Queue, Full
 from threading import Thread
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class _ThumbWorker():
@@ -41,8 +45,8 @@ class ThumbQueue():
         try:
             ThumbQueue._THUMB_QUEUE.put_nowait(image_obj)
         except Full:
-            # TODO: log or raise an exception in case of error
-            pass
+            logger.error('ThumbQueue FULL, not able to append new task')
+            # TODO: update image object for noting failed thumbnail generation
 
     @staticmethod
     def is_empty():

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -28,7 +28,7 @@ class _ThumbWorker():
         self._work_queue.append(work)
 
     def stop(self):
-        for thread in self._queue:
+        for thread in self._work_queue:
             thread.join()
 
 

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -1,0 +1,55 @@
+from django.conf.settings import THUMB_QUEUE_THREAD_COUNT
+import queue
+import threading
+import time
+
+
+class _ThumbWorker():
+    def __init__(self, thumb_queue):
+        self._queue = thumb_queue
+        self._work_queue = []
+
+    def work(self):
+        while True:
+            try:
+                image_obj = self._queue.get_nowait()  # noqa
+            except queue.Empty:
+                # TODO: find method to put thread to sleep when no upload
+                time.sleep(1)
+                continue
+
+            if image_obj is None:
+                break
+
+            # TODO: add actual thumbnail generation
+            self._queue.task_done()
+
+    def append(self, work):
+        self._work_queue.append(work)
+
+    def stop(self):
+        for thread in self._queue:
+            thread.join()
+
+
+class ThumbQueue():
+    _THUMB_QUEUE = queue.Queue(maxsize=THUMB_QUEUE_THREAD_COUNT)
+    worker = _ThumbWorker(_THUMB_QUEUE)
+
+    for _ in range(THUMB_QUEUE_THREAD_COUNT):
+        thread = threading.Thread(target=worker.work)
+        thread.start()
+        worker.append(thread)
+
+    @staticmethod
+    def add_image_obj(image_obj):
+        ThumbQueue._THUMB_QUEUE.put(image_obj)
+
+    @staticmethod
+    def stop():
+        ThumbQueue._THUMB_QUEUE.join()
+
+        for _ in range(THUMB_QUEUE_THREAD_COUNT):
+            ThumbQueue._THUMB_QUEUE.put(None)
+
+        ThumbQueue.worker.stop()

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -7,7 +7,7 @@ import time
 class _ThumbWorker():
     def __init__(self, thumb_queue):
         self._queue = thumb_queue
-        self._work_queue = []
+        self._pool = []
 
     def work(self):
         while True:
@@ -25,10 +25,10 @@ class _ThumbWorker():
             self._queue.task_done()
 
     def append(self, work):
-        self._work_queue.append(work)
+        self._pool.append(work)
 
     def stop(self):
-        for thread in self._work_queue:
+        for thread in self._pool:
             thread.join()
 
 

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -19,7 +19,7 @@ class _ThumbWorker():
             # TODO: add actual thumbnail generation
             self._queue.task_done()
 
-    def append(self, work):
+    def add(self, work):
         self._pool.append(work)
 
     def stop(self):
@@ -29,12 +29,12 @@ class _ThumbWorker():
 
 class ThumbQueue():
     _THUMB_QUEUE = queue.Queue(maxsize=THUMB_QUEUE_THREAD_COUNT)
-    worker = _ThumbWorker(_THUMB_QUEUE)
+    _WORKER = _ThumbWorker(_THUMB_QUEUE)
 
     for _ in range(THUMB_QUEUE_THREAD_COUNT):
         thread = threading.Thread(target=worker.work)
         thread.start()
-        worker.append(thread)
+        _WORKER.add(thread)
 
     @staticmethod
     def add_image_obj(image_obj):
@@ -47,4 +47,4 @@ class ThumbQueue():
         for _ in range(THUMB_QUEUE_THREAD_COUNT):
             ThumbQueue._THUMB_QUEUE.put(None)
 
-        ThumbQueue.worker.stop()
+        ThumbQueue._WORKER.stop()

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -12,6 +12,7 @@ class _ThumbWorker():
         while True:
             image_obj = self._queue.get()
 
+            # None indicates that the thread should die
             if image_obj is None:
                 break
 
@@ -47,6 +48,7 @@ class ThumbQueue():
     def stop():
         ThumbQueue._THUMB_QUEUE.join()
 
+        # Notify threads in thread-pool in _WORKER of death
         for _ in range(THUMB_QUEUE_THREAD_COUNT):
             ThumbQueue._THUMB_QUEUE.put(None)
 

--- a/fotogalleri/backend/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail_queue.py
@@ -11,12 +11,7 @@ class _ThumbWorker():
 
     def work(self):
         while True:
-            try:
-                image_obj = self._queue.get_nowait()  # noqa
-            except queue.Empty:
-                # TODO: find method to put thread to sleep when no upload
-                time.sleep(1)
-                continue
+            image_obj = self._queue.get()
 
             if image_obj is None:
                 break

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -75,20 +75,20 @@ WSGI_APPLICATION = 'fotogalleri.wsgi.application'
 
 # Logging
 if not DEBUG:
-    logging = {
+    LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
         'handlers': {
             'file': {
-                'level': 'info',
-                'class': 'logging.filehandler',
+                'level': 'INFO',
+                'class': 'logging.FileHandler',
                 'filename': '/var/log/fotogalleri/info.log',
             },
         },
         'loggers': {
             'django': {
                 'handlers': ['file'],
-                'level': 'info',
+                'level': 'INFO',
                 'propagate': True,
             },
         },

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -91,6 +91,10 @@ if not DEBUG:
                 'level': 'INFO',
                 'propagate': True,
             },
+            'django_auth_ldap': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
         },
     }
 

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -165,3 +165,6 @@ REST_FRAMEWORK = {
 # Confs necessary for ajax-select
 AJAX_SELECT_INLINES = 'staticfiles'
 STATIC_ROOT = env("STATIC_ROOT", None)
+
+# Conf for thumbnail queue
+THUMB_QUEUE_THREAD_COUNT = env('THUMB_QUEUE_THREAD_COUNT', 4)


### PR DESCRIPTION
This PR introduces a queueing system for thumbnail generation.

The queueing system is multi-threaded, where each thread handles one thumbnail generation at a time. This ensures that generation is non-blocking.

We still need to insert the thumbnail generation into the worker, as well as some class for keeping up with state.

~*Note*: do not merge before https://github.com/Teknologforeningen/fotogalleri/pull/5~