### PR TITLE
Save ImageMetadata after changing it

### DIFF
--- a/fotogalleri/backend/models.py
+++ b/fotogalleri/backend/models.py
@@ -70,6 +70,7 @@ class ImageMetadata(Model):
                 self.image.name = newfile
                 self.image.close()
                 self.image.storage.delete(oldfile)
+                self.save()
 
             if not self.path:
                 root_image, created = RootImage.objects.get_or_create(image_metadata=self)


### PR DESCRIPTION
This PR fixes a proper bug in the system: you were not able to upload images without generating thumbnails.

This was because we had forgotten to save an ImageMetadata instance after changing within its own save method.