### PR TITLE
Hard-code STATIC_ROOT

### DIFF
--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -170,7 +170,6 @@ REST_FRAMEWORK = {
 
 # Confs necessary for ajax-select
 AJAX_SELECT_INLINES = 'staticfiles'
-# STATIC_ROOT = env("STATIC_ROOT", None)
 STATIC_ROOT = os.path.join(BASE_DIR, 'gallery/static')
 
 # Conf for thumbnail queue


### PR DESCRIPTION
This PR hard-codes the `STATIC_ROOT` setting in `settings.py`.

This needs to be enabled as Django requires this instantly when pushing to production.