### PR TITLE
Fix reload issue in development

### DIFF
--- a/fotogalleri/backend/thumbnail/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail/thumbnail_queue.py
@@ -44,6 +44,7 @@ class ThumbQueue():
 
     for _ in range(settings.THUMB_QUEUE_THREAD_COUNT):
         thread = Thread(target=_WORKER.work)
+        thread.setDaemon(True)
         thread.start()
         _WORKER.add(thread)
 


### PR DESCRIPTION
This PR fixes an annoying development bug that has existed for a while, namely that `runserver` autoreloading hangs on the thumbnail creation threads.

The fix was simply to set `setDaemon` to `True` for each spawned thread, which makes them listen to the main thread that spawned them (i.e. Django) so they die if the parent dies.