### PR TITLE
Optional thumbnail gen

### DIFF
--- a/fotogalleri/.env.example
+++ b/fotogalleri/.env.example
@@ -54,3 +54,6 @@ LDAP_STAFF_GROUP_DN="cn=SOMEONE,dc=teknologforeningen,dc=fi"
 
 # Thread amount for thumbnail queue
 THUMB_QUEUE_THREAD_COUNT=4
+
+# Flag for enabling thumbnail generation
+ENABLE_THUMB_QUEUE=False

--- a/fotogalleri/backend/thumbnail/thumbnail_queue.py
+++ b/fotogalleri/backend/thumbnail/thumbnail_queue.py
@@ -42,10 +42,11 @@ class ThumbQueue():
     _THUMB_QUEUE = Queue()
     _WORKER = _ThumbWorker(_THUMB_QUEUE)
 
-    for _ in range(settings.THUMB_QUEUE_THREAD_COUNT):
-        thread = Thread(target=_WORKER.work)
-        thread.start()
-        _WORKER.add(thread)
+    if settings.ENABLE_THUMB_QUEUE:
+        for _ in range(settings.THUMB_QUEUE_THREAD_COUNT):
+            thread = Thread(target=_WORKER.work)
+            thread.start()
+            _WORKER.add(thread)
 
     @staticmethod
     def add_image_obj(image_obj):

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -176,6 +176,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'gallery/static')
 # Conf for thumbnail queue
 THUMB_QUEUE_THREAD_COUNT = env('THUMB_QUEUE_THREAD_COUNT', 4)
 
+# Enable thumbnail generation
+ENABLE_THUMB_QUEUE = env('ENABLE_THUMB_QUEUE', False)
+
 # LDAP Stuff
 
 # Baseline configuration.

--- a/fotogalleri/gallery/forms.py
+++ b/fotogalleri/gallery/forms.py
@@ -1,6 +1,7 @@
 from django.forms import ModelForm, CharField
 from django.forms.widgets import TextInput, PasswordInput
 from django.contrib.auth.forms import AuthenticationForm
+from django.conf import settings
 from backend.models import ImageMetadata, ImagePath
 from backend.thumbnail.thumbnail_queue_image_object import ThumbQueueImageObject
 from backend.thumbnail.thumbnail_queue import ThumbQueue
@@ -24,8 +25,8 @@ class ImageUploadForm(ModelForm):
         if commit:
             instance.path = self._create_image_path()
             instance.save()
-            thumbnail_generator = ThumbQueueImageObject(instance)
-            ThumbQueue.add_image_obj(thumbnail_generator)
+            if settings.ENABLE_THUMB_QUEUE:
+                self._enqueue_thumbnail(instance)
 
         return instance
 
@@ -39,6 +40,10 @@ class ImageUploadForm(ModelForm):
             current = sub
 
         return current
+
+    def _enqueue_thumbnail(self, instance):
+        thumbnail_generator = ThumbQueueImageObject(instance)
+        ThumbQueue.add_image_obj(thumbnail_generator)
 
 
 class CustomLoginForm(AuthenticationForm):


### PR DESCRIPTION
This PR enables optional Thumbnail generation in the project. To enable thumbnail generation a user has to set the environmental variable `ENABLE_THUMB_QUEUE` to `True`.

This also fixes a bug where threads are created in vain when working with Django commands.