### PR TITLE
Hide "See public pictures" button

### DIFF
--- a/fotogalleri/gallery/templates/landing_page.html
+++ b/fotogalleri/gallery/templates/landing_page.html
@@ -32,7 +32,8 @@
             {% include 'components/styled_button.html' with button_text="Till bilderna" url_name="view"|rev only %}
           {% else %}
             {% include 'components/styled_button.html' with button_text="Logga in" url_name="login"|rev only  %}
-            {% include 'components/styled_button.html' with button_text="Fortsätt utan inloggning" url_name="view"|rev only %}
+            {# TODO: uncheck this once public images are supported #}
+            {# include 'components/styled_button.html' with button_text="Fortsätt utan inloggning" url_name="view"|rev only #}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
UI and UX change to hide "View public images" button.

![2019-11-22-233640_1365x767_scrot](https://user-images.githubusercontent.com/23499634/69462265-39ce8700-0d81-11ea-8d53-3f6cf72ecd4d.png)


Public images are not yet supported.