### PR TITLE
Remove Lorem Ipsum text

### DIFF
--- a/fotogalleri/gallery/templates/landing_page.html
+++ b/fotogalleri/gallery/templates/landing_page.html
@@ -20,12 +20,7 @@
           FAFA Alternativt FotoAlbum
         </h2>
 
-        <div class="centered-text landing-text-margin">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </div>
+        <div class="centered-text landing-text-margin"></div>
 
         <div class="navigation-buttons-style">
           {% if logged_in %}


### PR DESCRIPTION
Removes the currently displayed `Lorem ipsum` text from the landing page. I found it quite beautiful without any text as well, so I simply deleted the content.

![2019-11-22-234450_1365x767_scrot](https://user-images.githubusercontent.com/23499634/69462745-7fd81a80-0d82-11ea-896f-3c6ce1738da5.png)
