### PR TITLE
Add PEP8 check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,9 @@ root = true
 [*]
 indent_style = space
 
+[Makefile]
+indent_style = tab
+
 [*.{html,yml}]
 indent_size = 2
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ serve: bin/python
 shell: bin/python
 	bin/python fotogalleri/manage.py shell
 
+test: bin/python
+	bin/python fotogalleri/manage.py test
+
+test-pep8: bin/python
+	bin/python fotogalleri/manage.py test test_pep8
+
+test-all: bin/python
+	$(MAKE) test
+	$(MAKE) test-pep8
+
 clean:
 	rm -rf build/ dist/ *.egg-info/ local/
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,28 @@
-VENV=.
-
-install: $(VENV)/bin/python
-
+# Setup virtualenv if not already existing
 bin/python:
 	virtualenv -p /usr/bin/python .
-	$(VENV)/bin/pip install -r requirements.txt
+	bin/pip install -r requirements.txt
 
 migrate: bin/python
-	$(VENV)/bin/python fotogalleri/manage.py migrate
-
-serve: bin/python
-	$(VENV)/bin/python fotogalleri/manage.py runserver 8888
-
-deploy: bin/python
-	$(VENV)/bin/python fotogalleri/manage.py collectstatic -v0 --noinput
-	touch fotogalleri/fotogalleri/wsgi.py
+	bin/python fotogalleri/manage.py migrate
 
 migrations: bin/python
-	$(VENV)/bin/python fotogalleri/manage.py makemigrations
+	bin/python fotogalleri/manage.py makemigrations
+
+deploy: bin/python
+	bin/python fotogalleri/manage.py collectstatic -v0 --noinput
+	touch fotogalleri/fotogalleri/wsgi.py
+
+# Development specific
+serve: bin/python
+	bin/python fotogalleri/manage.py runserver 8888
 
 shell: bin/python
-	$(VENV)/bin/python fotogalleri/manage.py shell
+	bin/python fotogalleri/manage.py shell
 
 clean:
-	rm -rf build/ dist/ *.egg-info/ local/ $(VENV)/bin $(VENV)/lib $(VENV)/include
+	rm -rf build/ dist/ *.egg-info/ local/
+
+clean-all:
+	$(MAKE) clean
+	rm -rf bin lib include

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -225,3 +225,9 @@ AUTHENTICATION_BACKENDS = (
 AUTH_LDAP_GLOBAL_OPTIONS = {
     OPT_X_TLS_REQUIRE_CERT: OPT_X_TLS_NEVER
 }
+
+# PEP8 settings
+TEST_PEP8_DIRS = [os.path.dirname(PROJECT_DIR)]
+TEST_PEP8_EXCLUDE = ['migrations']
+TEST_PEP8_IGNORE = []
+TEST_PEP8_CONFIG_FILE = os.path.join(os.path.dirname(BASE_DIR), 'setup.cfg')

--- a/fotogalleri/fotogalleri/tests_pep8.py
+++ b/fotogalleri/fotogalleri/tests_pep8.py
@@ -1,0 +1,5 @@
+from test_pep8.tests import PEP8Test
+
+__all__ = [
+    'PEP8Test',
+]


### PR DESCRIPTION
This PR adds PEP8 tests for our project, now also available through `make test-pep8`.

Additionally, this PR cleans up the `Makefile` and adds some new rules.