### PR TITLE
Setup job dependencies and use needed action

### DIFF
--- a/.github/workflows/fotogalleri-ci.yml
+++ b/.github/workflows/fotogalleri-ci.yml
@@ -13,13 +13,19 @@ jobs:
           python-version: 3.5
   lint:
     runs-on: ubuntu-16.04
+    needs: setup
     steps:
+      # Without the following action the Makefile won't be found
+      - uses: actions/checkout@v1
       - name: Lint with PEP8
         run:
           make test-pep8
   test:
     runs-on: ubuntu-16.04
+    needs: setup
     steps:
+      # Without the following action the Makefile won't be found
+      - uses: actions/checkout@v1
       - name: Run tests
         run:
           make test


### PR DESCRIPTION
This PR sets up needed dependencies between our GitHub action jobs, and uses the `actions/checkout` action to use our custom `Makefile`.