### PR TITLE
PEP8 to pycodestyle

### DIFF
--- a/.github/requirements.github.txt
+++ b/.github/requirements.github.txt
@@ -7,3 +7,4 @@ django-getenv>=1.3.2
 Pillow==6.2.0
 tqdm==4.32.2
 dj-database-url>=0.4.2
+pycodestyle==2.5.0

--- a/.github/workflows/fotogalleri-ci.yml
+++ b/.github/workflows/fotogalleri-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install virtualenv
         run: pip install virtualenv
       - name: Lint with PEP8
-        run: make REQUIREMENTS_FILE=.github/requirements.github.txt test-pep8
+        run: make REQUIREMENTS_FILE=.github/requirements.github.txt lint
   test:
     runs-on: ubuntu-16.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,6 @@ test: bin/python
 test-pep8: bin/python
 	bin/python fotogalleri/manage.py test test_pep8
 
-test-all: bin/python
-	$(MAKE) test
-	$(MAKE) test-pep8
 
 clean:
 	rm -rf build/ dist/ *.egg-info/ local/

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,8 @@ shell: bin/python
 test: bin/python
 	bin/python fotogalleri/manage.py test fotogalleri
 
-test-pep8: bin/python
-	bin/python fotogalleri/manage.py test test_pep8
-
+lint: bin/python
+	bin/python -m pycodestyle --exclude=migrations fotogalleri
 
 clean:
 	rm -rf build/ dist/ *.egg-info/ local/

--- a/fotogalleri/fotogalleri/settings.py
+++ b/fotogalleri/fotogalleri/settings.py
@@ -225,9 +225,3 @@ AUTHENTICATION_BACKENDS = (
 AUTH_LDAP_GLOBAL_OPTIONS = {
     OPT_X_TLS_REQUIRE_CERT: OPT_X_TLS_NEVER
 }
-
-# PEP8 settings
-TEST_PEP8_DIRS = [os.path.dirname(PROJECT_DIR)]
-TEST_PEP8_EXCLUDE = ['migrations']
-TEST_PEP8_IGNORE = []
-TEST_PEP8_CONFIG_FILE = os.path.join(os.path.dirname(BASE_DIR), 'setup.cfg')

--- a/fotogalleri/fotogalleri/tests_pep8.py
+++ b/fotogalleri/fotogalleri/tests_pep8.py
@@ -1,5 +1,0 @@
-from test_pep8.tests import PEP8Test
-
-__all__ = [
-    'PEP8Test',
-]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Pillow==6.2.0
 tqdm==4.32.2
 dj-database-url>=0.4.2
 psycopg2>=2.7.5
+pycodestyle==2.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 max-line-length = 119
 
 [flake8]


### PR DESCRIPTION
This PR removes the usage of `pep8` and updates it to `pycodestyles`.

`pycodestyles` is a renamed and the current development version of `pep8`.