### PR TITLE
Sort paths and images by name

### DIFF
--- a/fotogalleri/gallery/views.py
+++ b/fotogalleri/gallery/views.py
@@ -35,8 +35,8 @@ class ImageGalleryView(ListView):
         return [object for object in object_list if not object.hidden]
 
     def _render_root(self, request):
-        root_children = RootPath.objects.all()
-        root_images = RootImage.objects.all()
+        root_children = RootPath.objects.all().order_by('image_path__path')
+        root_images = RootImage.objects.all().order_by('image_metadata__image')
         folders = [path.image_path for path in root_children]
         images = [image.image_metadata for image in root_images]
 
@@ -57,8 +57,8 @@ class ImageGalleryView(ListView):
             child = get_object_or_404(ImagePath, parent=current, path=part)
             current = child
 
-        folders = ImagePath.objects.filter(parent=current)
-        images = ImageMetadata.objects.filter(path=current)
+        folders = ImagePath.objects.filter(parent=current).order_by('path')
+        images = ImageMetadata.objects.filter(path=current).order_by('image')
 
         if not self.context['is_admin']:
             folders = self._exclude_hidden(folders)


### PR DESCRIPTION
This PR introduces a naïve solution to sorting: sort by name.

Sorting by name allows a deterministic view of all folders. Additionally, images from DSLRs are usually are usually named with IDs, so they are inherently sequential in snap order (except when the naming is wrapped around, but this is an edge-case on the DSLR side).