### PR TITLE
Remove new path error messages when closing the modal

### DIFF
--- a/fotogalleri/gallery/static/javascript/new_path.js
+++ b/fotogalleri/gallery/static/javascript/new_path.js
@@ -19,10 +19,12 @@ function getCookie(name) {
 }
 
 $(function () {
+    $('#new-path-form-close').click(function() {
+        $('#error-msg').remove();
+    });
+
     $('#new-path-button').click(function () {
         if (!!$('#new-path').val()) {
-            // TODO: error message is only removed when a valid folder name is posted.
-            // It should be removed when the modal is closed
             $('#error-msg').remove();
             const crsfToken = getCookie('csrftoken');
             const [{ name, value } = {}] = $('#new-path-form').serializeArray();

--- a/fotogalleri/gallery/templates/modals/create_path.html
+++ b/fotogalleri/gallery/templates/modals/create_path.html
@@ -10,7 +10,7 @@
   <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title">Add path</p>
-      <button class="delete" aria-label="close"></button>
+      <button id="new-path-form-close" class="delete" aria-label="close"></button>
     </header>
     <section class="modal-card-body">
       <form id="new-path-form" method="POST">


### PR DESCRIPTION
Addresses #51.

Currently, error messages persist even after closing the new path modal and reopening it. The only way to remove an error message is by submitting a valid path or refreshing the page.

This PR fixes this bug by clearing the message every time the close button is clicked.