### PR TITLE
Prevent POST failure for new path submission when pressing enter

### DIFF
--- a/fotogalleri/gallery/static/javascript/new_path.js
+++ b/fotogalleri/gallery/static/javascript/new_path.js
@@ -23,7 +23,16 @@ $(function () {
         $('#error-msg').remove();
     });
 
-    $('#new-path-button').click(function () {
+    $('#new-path-form').keydown(function (event) {
+        if (event.keyCode === 13) {
+            $('#new-path-form').submit();
+            event.preventDefault();
+        }
+    });
+
+    $('#new-path-form').submit(function (event) {
+        event.preventDefault();
+
         if (!!$('#new-path').val()) {
             $('#error-msg').remove();
             const crsfToken = getCookie('csrftoken');

--- a/fotogalleri/gallery/templates/modals/create_path.html
+++ b/fotogalleri/gallery/templates/modals/create_path.html
@@ -7,20 +7,20 @@
 {% endblock %}
 
 {% block modalcontent %}
+<form id="new-path-form">
   <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title">Add path</p>
       <button id="new-path-form-close" class="delete" aria-label="close"></button>
     </header>
     <section class="modal-card-body">
-      <form id="new-path-form" method="POST">
-        <input id="new-path" name="path" placeholder="Insert new path">
-      </form>
+      <input id="new-path" name="path" placeholder="Insert new path">
     </section>
     <footer class="modal-card-foot">
       <div id="new-path-button">
-        {% include 'components/styled_button.html' with button_text="Create new path" url_name="javascript:;" sizes="is-size-6" only %}
+        {% include 'components/styled_button.html' with type="button" button_text="Create new path" url_name="javascript:;" sizes="is-size-6" only %}
       </div>
     </footer>
   </div>
+</form>
 {% endblock %}

--- a/fotogalleri/gallery/templates/modals/create_path.html
+++ b/fotogalleri/gallery/templates/modals/create_path.html
@@ -18,7 +18,7 @@
     </section>
     <footer class="modal-card-foot">
       <div id="new-path-button">
-        {% include 'components/styled_button.html' with type="button" button_text="Create new path" url_name="javascript:;" sizes="is-size-6" only %}
+        {% include 'components/styled_button.html' with button_text="Create new path" url_name="javascript:;" sizes="is-size-6" only %}
       </div>
     </footer>
   </div>


### PR DESCRIPTION
When pressing enter in the new path form, the browser does a POST form submission and redirects the user to `/newfolder/`. However, as the submission is supposed to be done as a AJAX request and doesn't have the proper parameters the requests fails and an error page is shown to the user:

<img width="661" alt="Screenshot 2020-01-02 at 21 39 25" src="https://user-images.githubusercontent.com/14876246/71691728-5f02dc00-2da8-11ea-8729-4b77f93ad808.png">

This pull request prevents the Enter key from submitting the form and calls the AJAX submission instead.