### PR TITLE
Hidden folder tag

### DIFF
--- a/fotogalleri/gallery/static/css/folder.css
+++ b/fotogalleri/gallery/static/css/folder.css
@@ -38,3 +38,14 @@
 .folder-link:hover::before {
     color: rgb(255, 153, 161);
 }
+
+.hidden-folder-tag {
+    border-color: var(--dark-red);
+    color: var(--dark-red);
+    border-width: 1px;
+    border-style: solid;
+}
+
+.has-margin-left-10 {
+    margin-left: 10px;
+}

--- a/fotogalleri/gallery/templates/components/folder.html
+++ b/fotogalleri/gallery/templates/components/folder.html
@@ -7,6 +7,6 @@
   data-url="/view/{{ folder.full_path }}"
   data-id="{{ folder.pk }}"
 >
-{{ folder.path }}
   <input type="checkbox" style="display: none; margin-left: 10px;" />  
+  {{ folder.path }}
 </a>

--- a/fotogalleri/gallery/templates/components/folder.html
+++ b/fotogalleri/gallery/templates/components/folder.html
@@ -7,6 +7,11 @@
   data-url="/view/{{ folder.full_path }}"
   data-id="{{ folder.pk }}"
 >
-  <input type="checkbox" style="display: none; margin-left: 10px;" />  
   {{ folder.path }}
+
+  {% if folder.hidden %}
+    <span class="tag hidden-folder-tag is-normal has-margin-left-10">Hidden</span>
+  {% endif %}
+
+  <input type="checkbox" class="has-margin-left-10" style="display: none;" />
 </a>

--- a/fotogalleri/gallery/templates/view_images.html
+++ b/fotogalleri/gallery/templates/view_images.html
@@ -38,12 +38,12 @@
       class="content folders-content"
       style="{% if not folders %}display: none;{% endif %}"
     >
-    <div>
-      {% for folder in folders %}
       <div>
-        {% include "components/folder.html" with folder=folder %}
-      </div>
-      {% endfor %}
+        {% for folder in folders %}
+          <div>
+            {% include "components/folder.html" with folder=folder %}
+          </div>
+        {% endfor %}
       </div>
     </div>
 


### PR DESCRIPTION
This stylistic addition adds a tag that says `Hidden` for hidden folders.

![2020-01-24-011059_228x91_scrot](https://user-images.githubusercontent.com/23499634/73007333-5487af80-3e47-11ea-8cf0-bdffea4b60fa.png)
