### PR TITLE
Admin select all

### DIFF
--- a/fotogalleri/gallery/static/css/components/toolbar.css
+++ b/fotogalleri/gallery/static/css/components/toolbar.css
@@ -13,6 +13,10 @@
     font-weight: 600;
 }
 
+#select-all-objects-button {
+    display: none;
+}
+
 #delete-button {
     display: none;
 }

--- a/fotogalleri/gallery/static/javascript/select.js
+++ b/fotogalleri/gallery/static/javascript/select.js
@@ -28,10 +28,35 @@ function selectFolderLink(component) {
 }
 
 $(function() {
+    const selectAllButton = $('#select-all-objects-button');
+    selectAllButton.click(function() {
+        const isPressed = selectAllButton.attr('pressed');
+
+        $('[selectable="true"]').each(function(index, selectable) {
+            const classNames = selectable.className.split(' ');
+            const filteredNames = classNames.filter(function(className) {
+                return className !== 'selectable';
+            });
+
+            filteredNames.forEach(function() {
+                const checkbox = $(selectable).children('[type="checkbox"]');
+                checkbox.prop('checked', !isPressed);
+            });
+        });
+
+        selectAllButton.attr('pressed', !!isPressed ? '' : 'true')
+        selectAllButton.find('button').text(
+            !!isPressed
+            ? 'Select all'
+            : 'Disselect all'
+        );
+    });
+
     const selectButton = $('#select-objects-button')
     selectButton.click(function() {
         const deleteButton = $('#delete-button');
         deleteButton.toggle();
+        selectAllButton.toggle();
         selectButton.find("button").toggleClass("styled-button-admin-selected")
 
         $('[selectable="true"]').each(function(index, selectable) {

--- a/fotogalleri/gallery/static/javascript/select.js
+++ b/fotogalleri/gallery/static/javascript/select.js
@@ -48,7 +48,7 @@ $(function() {
         selectAllButton.find('button').text(
             !!isPressed
             ? 'Select all'
-            : 'Disselect all'
+            : 'Deselect all'
         );
     });
 

--- a/fotogalleri/gallery/templates/components/toolbar.html
+++ b/fotogalleri/gallery/templates/components/toolbar.html
@@ -34,6 +34,9 @@
         {% include 'components/styled_button.html' with button_text="Select & Delete" style="admin" sizes="is-size-6" only %}
       </div>
 
+      <div id="select-all-objects-button" pressed="">
+        {% include 'components/styled_button.html' with button_text="Select all" style="secondary" sizes="is-size-6" only %}
+      </div>
 
       <div id="delete-button">
         {% include 'components/styled_button.html' with button_text="DELETE" style="secondary" sizes="is-size-6" only %}

--- a/fotogalleri/gallery/templates/components/toolbar.html
+++ b/fotogalleri/gallery/templates/components/toolbar.html
@@ -12,33 +12,32 @@
 
   <div class="content toolbar-outer">
     <div class="toolbar-title is-size-5">
-    
       <i class="vertical-line line-is-admin"></i>
       Adminverktyg
     </div>
+
     <div class="buttons">
+      {% include 'components/image_upload_form.html' %}
+      <div id="js-upload-photos">
+        {% include 'components/styled_button.html' with button_text="Upload" style="admin" sizes="is-size-6" only %}
+      </div>
 
-        {% include 'components/image_upload_form.html' %}
-        <div id="js-upload-photos">
-          {% include 'components/styled_button.html' with button_text="Upload" style="admin" sizes="is-size-6" only %}
+      {% with 'create-path' as modal_id %}
+        <div data-toggle="modal" data-target="{{ modal_id }}">
+          {% include 'components/styled_button.html' with button_text="New folder" style="admin" sizes="is-size-6" only %}
         </div>
 
-        {% with 'create-path' as modal_id %}
-          <div data-toggle="modal" data-target="{{ modal_id }}">
-            {% include 'components/styled_button.html' with button_text="New folder" style="admin" sizes="is-size-6" only %}
-          </div>
+        {% include "modals/create_path.html" with modalname=modal_id only %}
+      {% endwith %}
 
-          {% include "modals/create_path.html" with modalname=modal_id only %}
-        {% endwith %}
+      <div id="select-objects-button">
+        {% include 'components/styled_button.html' with button_text="Select & Delete" style="admin" sizes="is-size-6" only %}
+      </div>
 
-        <div id="select-objects-button">
-          {% include 'components/styled_button.html' with button_text="Select & Delete" style="admin" sizes="is-size-6" only %}
-        </div>
 
-        <div id="delete-button">
-          {% include 'components/styled_button.html' with button_text="DELETE" style="secondary" sizes="is-size-6" only %}
-        </div>
-      
+      <div id="delete-button">
+        {% include 'components/styled_button.html' with button_text="DELETE" style="secondary" sizes="is-size-6" only %}
+      </div>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
This PR adds a `Select all` button to the admin toolbar. When pressed it selects all selectable objects and turns into a `Disselect all` button.

Fixes https://github.com/Teknologforeningen/fotogalleri/issues/67

![2020-01-24-171508_1116x167_scrot](https://user-images.githubusercontent.com/23499634/73057686-17fe9700-3ecd-11ea-8cce-b99a69b2149c.png)
