### PR TITLE
Support opening links and images in new tabs and windows

### DIFF
--- a/fotogalleri/gallery/static/javascript/select.js
+++ b/fotogalleri/gallery/static/javascript/select.js
@@ -3,15 +3,13 @@ function selectLinkOnClick(link) {
     const checkboxIsHidden = checkbox.is(':hidden');
 
     if (checkboxIsHidden) {
-        const linkUrl = $(link).attr('data-url');
-        window.location.href = linkUrl;
+        return
+    }
+    const checkboxIsChecked = checkbox.is(':checked');
+    if (checkboxIsChecked) {
+        checkbox.removeAttr('checked');
     } else {
-        const checkboxIsChecked = checkbox.is(':checked');
-        if (checkboxIsChecked) {
-            checkbox.removeAttr('checked');
-        } else {
-            checkbox.attr('checked', 'checked');
-        }
+        checkbox.attr('checked', 'checked');
     }
 }
 
@@ -64,6 +62,12 @@ $(function() {
             const filteredNames = classNames.filter(function(className) {
                 return className !== 'selectable';
             });
+
+            if ($(selectable).attr("href")) {
+                $(selectable).removeAttr("href")
+            } else {
+                $(selectable).attr("href", $(selectable).attr("data-url"))
+            }
 
             filteredNames.forEach(function(className) {
                 switch (className) {

--- a/fotogalleri/gallery/templates/components/folder.html
+++ b/fotogalleri/gallery/templates/components/folder.html
@@ -1,6 +1,7 @@
 {% load static %}
 
 <a
+  href="/view/{{ folder.full_path }}"
   onClick="selectLinkOnClick(this)"
   class="folder-link"
   selectable="true"

--- a/fotogalleri/gallery/templates/components/thumbnail.html
+++ b/fotogalleri/gallery/templates/components/thumbnail.html
@@ -7,6 +7,7 @@
 {% with width=image.image.width height=image.image.height %}
   <a
     onClick="selectLinkOnClick(this)"
+    href="{{ image.image.url }}"
     class="img-link selectable"
     style="width:{% widthratio width height 300 %}px;flex-grow:{% widthratio width height 300 %};"
     selectable="true"


### PR DESCRIPTION
Currently, clicking on a link or image triggers a JavaScript function that navigation by changing `window.location.href`. The purpose seems to be to support quick selection of images in the admin mode, but it also has the  nasty side effect that images cannot be opened in new tabs or windows by ctrl/cmd+clicking or even right clicking.

This pull request changes the behavior so that navigation for normal users is done using `<a href="link" />` technology (🤯), but preserves the present behavior for admin users (clicking the image selects it when in selection mode).